### PR TITLE
Run integtest provider calls by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aplassard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run --env-file .env pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,4 +25,9 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: uv run --env-file .env pytest
+        run: |
+          if [ -f .env ]; then
+            uv run --env-file .env pytest
+          else
+            uv run pytest
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,4 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: |
-          if [ -f .env ]; then
-            uv run --env-file .env pytest
-          else
-            uv run pytest
-          fi
+        run: uv run pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# successat contributor notes
+
+## Tooling
+- Use [uv](https://docs.astral.sh/uv/) for dependency management and commands.
+- Install or update dependencies with `uv sync`.
+- Run tests with `uv run --env-file .env pytest` so the local `.env` values are
+  loaded consistently.
+
+## Environment variables
+- The repository contains an `.env` file with placeholders for required API
+  keys. Do not commit real credentials and do not modify this file in pull
+  requests.
+- Application code should access credentials through environment variables or
+  the provided `from_env()` helpers in `successat.llm.clients`.
+
+## Testing guidance
+- Default unit tests can rely on mocked transports, but integration tests under
+  `tests/integration/test_live_llm_clients.py` call the real OpenAI and
+  OpenRouter APIs. They are marked with the `integtest` marker and are skipped
+  automatically when credentials are unavailable.
+- Run all checks with `uv run --env-file .env pytest`. To omit external calls in
+  local development, use `uv run --env-file .env pytest -m "not integtest"`.
+- Close instantiated `OpenAI` clients in tests to avoid resource warnings.
+
+Following these practices keeps local development, CI, and production
+configuration aligned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@
   automatically when credentials are unavailable.
 - Run all checks with `uv run --env-file .env pytest`. To omit external calls in
   local development, use `uv run --env-file .env pytest -m "not integtest"`.
+- GitHub Actions loads provider keys from repository secrets and automatically
+  falls back to `uv run pytest` when a `.env` file is not present.
 - Close instantiated `OpenAI` clients in tests to avoid resource warnings.
 
 Following these practices keeps local development, CI, and production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@
   automatically when credentials are unavailable.
 - Run all checks with `uv run --env-file .env pytest`. To omit external calls in
   local development, use `uv run --env-file .env pytest -m "not integtest"`.
-- GitHub Actions loads provider keys from repository secrets and automatically
-  falls back to `uv run pytest` when a `.env` file is not present.
+- GitHub Actions loads provider keys from repository secrets and runs
+  `uv run pytest`, relying on the injected environment variables instead of a
+  `.env` file.
 - Close instantiated `OpenAI` clients in tests to avoid resource warnings.
 
 Following these practices keeps local development, CI, and production

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ uv run --env-file .env pytest
 
 The `--env-file` flag ensures the `.env` file is loaded, keeping the test
 environment aligned with production usage when developing locally. Continuous
-integration loads provider credentials from GitHub secrets and falls back to
-`uv run pytest` automatically when a `.env` file is not present.
+integration loads provider credentials from GitHub secrets and runs `uv run
+pytest` directly without relying on a `.env` file.
 
 Integration tests that call the external APIs are marked with the `integtest`
 pytest marker. To focus on unit tests locally you can exclude them:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ uv run --env-file .env pytest
 ```
 
 The `--env-file` flag ensures the `.env` file is loaded, keeping the test
-environment aligned with production usage. The same command is executed by the
-continuous integration workflow in `.github/workflows/ci.yml`.
+environment aligned with production usage when developing locally. Continuous
+integration loads provider credentials from GitHub secrets and falls back to
+`uv run pytest` automatically when a `.env` file is not present.
 
 Integration tests that call the external APIs are marked with the `integtest`
 pytest marker. To focus on unit tests locally you can exclude them:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,94 @@
 # successat
-Library to run LLM benchmarks
+
+Reusable benchmarking utilities for large language models (LLMs) with a
+focus on testable, provider-agnostic client integrations.
+
+## Project overview
+
+The project packages reusable LLM client abstractions under
+`successat.llm.clients`. Two concrete clients are included:
+
+* `OpenAIClient` – connects to OpenAI's API using the official SDK.
+* `OpenRouterClient` – connects to the OpenRouter API while reusing the same
+  SDK.
+
+Both clients share a common base class, default to the
+`gpt-5-nano` model, and identify themselves with the application name
+`successat`. The module is designed so downstream benchmarks can swap providers
+without changing business logic.
+
+## Prerequisites
+
+* [uv](https://docs.astral.sh/uv/) (package and project manager for Python)
+* Python 3.12 (managed automatically when using `uv`)
+
+## Environment configuration
+
+Credentials are read from environment variables and the repository ships with
+an `.env` file that defines the keys:
+
+* `OPENAI_API_KEY`
+* `OPENROUTER_API_KEY`
+
+Do **not** commit secret keys to version control. Populate the `.env` file
+locally or export the variables in your shell. The clients also expose
+`from_env()` helpers to read these values at runtime.
+
+## Installing dependencies
+
+Run the following command once to install (or update) the project dependencies
+defined in `pyproject.toml` and `uv.lock`:
+
+```bash
+uv sync
+```
+
+This will create a local virtual environment under `.venv/` if one does not
+already exist.
+
+## Running the test suite
+
+Unit and integration tests are managed with `pytest`. By default the suite will
+exercise real OpenAI and OpenRouter endpoints when valid credentials are
+available.
+
+```bash
+uv run --env-file .env pytest
+```
+
+The `--env-file` flag ensures the `.env` file is loaded, keeping the test
+environment aligned with production usage. The same command is executed by the
+continuous integration workflow in `.github/workflows/ci.yml`.
+
+Integration tests that call the external APIs are marked with the `integtest`
+pytest marker. To focus on unit tests locally you can exclude them:
+
+```bash
+uv run --env-file .env pytest -m "not integtest"
+```
+
+If a provider-specific model should be used instead of the default
+`gpt-5-nano`, set one of the following environment variables before running the
+tests:
+
+* `OPENAI_INTEG_MODEL`
+* `OPENROUTER_INTEG_MODEL`
+
+Tests are skipped automatically when a required API key is not available in the
+environment.
+
+## Example usage
+
+```python
+from successat.llm.clients import OpenAIClient, OpenRouterClient
+
+# Instantiate using environment variables defined in .env
+openai_client = OpenAIClient.from_env()
+router_client = OpenRouterClient.from_env()
+
+print(openai_client.chat("Explain reusable LLM benchmarking."))
+print(router_client.chat("Explain reusable LLM benchmarking."))
+```
+
+Remember that invoking the clients requires valid API keys; the example is
+intended for environments where the necessary credentials are available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,18 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "openai>=1.30.0",
+    "pytest>=7.4",
+]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+pythonpath = [
+    "src",
+]
+markers = [
+    "integtest: marks tests that call real provider APIs",
+]

--- a/src/successat/llm/__init__.py
+++ b/src/successat/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM client interfaces for the successat project."""
+
+from .clients import BaseLLMClient, OpenAIClient, OpenRouterClient
+
+__all__ = ["BaseLLMClient", "OpenAIClient", "OpenRouterClient"]

--- a/src/successat/llm/clients.py
+++ b/src/successat/llm/clients.py
@@ -1,0 +1,189 @@
+"""Client implementations for interacting with LLM providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Dict, Iterable, Mapping, Sequence
+
+from openai import OpenAI
+
+
+class BaseLLMClient(ABC):
+    """Abstract base class for LLM client implementations."""
+
+    env_var_name: ClassVar[str]
+    default_model: ClassVar[str] = "gpt-5-nano"
+    default_app_name: ClassVar[str] = "successat"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str | None = None,
+        app_name: str | None = None,
+        client_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not api_key:
+            msg = "An API key is required to create an LLM client."
+            raise ValueError(msg)
+
+        self.api_key = api_key
+        self.model = model or self.default_model
+        self.app_name = app_name or self.default_app_name
+        self._client_kwargs: Dict[str, Any] = dict(client_kwargs or {})
+        self._client = self._create_client()
+
+    @property
+    def client(self) -> OpenAI:
+        """Return the underlying OpenAI client instance."""
+
+        return self._client
+
+    def chat(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+        model: str | None = None,
+        extra_messages: Sequence[Mapping[str, str]] | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Execute a chat completion request and return the model response."""
+
+        messages: list[Dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+
+        messages.append({"role": "user", "content": prompt})
+
+        if extra_messages:
+            messages.extend({"role": msg["role"], "content": msg["content"]} for msg in extra_messages)
+
+        result = self.client.chat.completions.create(
+            model=model or self.model,
+            messages=messages,
+            **kwargs,
+        )
+        first_choice = result.choices[0]
+        message_content = getattr(first_choice.message, "content", "")
+
+        if isinstance(message_content, str):
+            return message_content
+
+        if isinstance(message_content, Iterable):
+            parts = []
+            for item in message_content:  # type: ignore[not-an-iterable]
+                text = getattr(item, "text", None)
+                if text:
+                    parts.append(text)
+            if parts:
+                return "".join(parts)
+
+        return ""
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        model: str | None = None,
+        app_name: str | None = None,
+        client_kwargs: Mapping[str, Any] | None = None,
+    ) -> "BaseLLMClient":
+        """Instantiate the client using credentials sourced from the environment."""
+
+        import os
+
+        api_key = os.getenv(cls.env_var_name)
+        if not api_key:
+            msg = f"Environment variable {cls.env_var_name} is required."
+            raise EnvironmentError(msg)
+
+        return cls(
+            api_key=api_key,
+            model=model,
+            app_name=app_name,
+            client_kwargs=client_kwargs,
+        )
+
+    @abstractmethod
+    def _create_client(self) -> OpenAI:
+        """Create and return the configured OpenAI client."""
+
+
+class OpenAIClient(BaseLLMClient):
+    """LLM client implementation backed by OpenAI's API."""
+
+    env_var_name: ClassVar[str] = "OPENAI_API_KEY"
+
+    def _create_client(self) -> OpenAI:  # pragma: no cover - exercised in integration tests
+        headers = self._build_default_headers()
+        client_kwargs = self._pop_client_kwargs()
+        client_kwargs.setdefault("default_headers", headers)
+
+        return OpenAI(api_key=self.api_key, **client_kwargs)
+
+    def _build_default_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {"User-Agent": self.app_name}
+        existing: Mapping[str, str] | None = None
+        if "default_headers" in self._client_kwargs:
+            raw_headers = self._client_kwargs["default_headers"]
+            if isinstance(raw_headers, Mapping):
+                existing = raw_headers
+        if existing:
+            headers = {**existing, **headers}
+        return headers
+
+    def _pop_client_kwargs(self) -> Dict[str, Any]:
+        kwargs = dict(self._client_kwargs)
+        kwargs.pop("default_headers", None)
+        return kwargs
+
+
+class OpenRouterClient(BaseLLMClient):
+    """LLM client implementation for the OpenRouter API."""
+
+    env_var_name: ClassVar[str] = "OPENROUTER_API_KEY"
+    base_url: ClassVar[str] = "https://openrouter.ai/api/v1"
+    default_referer: ClassVar[str] = "https://github.com/successat/successat"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str | None = None,
+        app_name: str | None = None,
+        referer: str | None = None,
+        client_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.referer = referer or self.default_referer
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            app_name=app_name,
+            client_kwargs=client_kwargs,
+        )
+
+    def _create_client(self) -> OpenAI:  # pragma: no cover - exercised in integration tests
+        headers = self._build_default_headers()
+        client_kwargs = dict(self._client_kwargs)
+        client_kwargs.pop("default_headers", None)
+        base_url = client_kwargs.pop("base_url", self.base_url)
+
+        return OpenAI(
+            api_key=self.api_key,
+            base_url=base_url,
+            default_headers=headers,
+            **client_kwargs,
+        )
+
+    def _build_default_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {
+            "HTTP-Referer": self.referer,
+            "X-Title": self.app_name,
+            "User-Agent": self.app_name,
+        }
+        if "default_headers" in self._client_kwargs and isinstance(
+            self._client_kwargs["default_headers"], Mapping
+        ):
+            headers = {**self._client_kwargs["default_headers"], **headers}
+        return headers

--- a/tests/integration/test_live_llm_clients.py
+++ b/tests/integration/test_live_llm_clients.py
@@ -1,0 +1,57 @@
+"""Integration tests that exercise the real provider APIs when credentials exist."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from successat.llm.clients import BaseLLMClient, OpenAIClient, OpenRouterClient
+
+pytestmark = pytest.mark.integtest
+
+
+def _client_from_env(client_cls: type[BaseLLMClient]) -> BaseLLMClient:
+    """Create a client instance, skipping the test if credentials are absent."""
+
+    try:
+        return client_cls.from_env()
+    except EnvironmentError as exc:  # pragma: no cover - exercised when keys absent
+        pytest.skip(str(exc))
+
+
+def _resolve_model(env_var: str, default: str) -> str:
+    override = os.getenv(env_var)
+    return override or default
+
+
+def test_openai_client_live_chat_completion() -> None:
+    client = _client_from_env(OpenAIClient)
+
+    try:
+        response = client.chat(
+            "Reply with a short acknowledgement of success.",
+            model=_resolve_model("OPENAI_INTEG_MODEL", client.model),
+            temperature=0,
+        )
+    finally:
+        client.client.close()
+
+    assert isinstance(response, str)
+    assert response.strip()
+
+
+def test_openrouter_client_live_chat_completion() -> None:
+    client = _client_from_env(OpenRouterClient)
+
+    try:
+        response = client.chat(
+            "Respond with a concise confirmation that OpenRouter is reachable.",
+            model=_resolve_model("OPENROUTER_INTEG_MODEL", client.model),
+            temperature=0,
+        )
+    finally:
+        client.client.close()
+
+    assert isinstance(response, str)
+    assert response.strip()

--- a/tests/integration/test_live_llm_clients.py
+++ b/tests/integration/test_live_llm_clients.py
@@ -32,7 +32,6 @@ def test_openai_client_live_chat_completion() -> None:
         response = client.chat(
             "Reply with a short acknowledgement of success.",
             model=_resolve_model("OPENAI_INTEG_MODEL", client.model),
-            temperature=0,
         )
     finally:
         client.client.close()
@@ -48,7 +47,6 @@ def test_openrouter_client_live_chat_completion() -> None:
         response = client.chat(
             "Respond with a concise confirmation that OpenRouter is reachable.",
             model=_resolve_model("OPENROUTER_INTEG_MODEL", client.model),
-            temperature=0,
         )
     finally:
         client.client.close()

--- a/tests/integration/test_llm_clients.py
+++ b/tests/integration/test_llm_clients.py
@@ -1,0 +1,68 @@
+"""Integration tests for the concrete LLM clients."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import httpx
+
+from successat.llm.clients import OpenAIClient, OpenRouterClient
+
+
+def _mock_chat_response(message: str, capture: Dict[str, Any]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        capture["payload"] = payload
+        capture["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"choices": [{"message": {"content": message}}]})
+
+    return httpx.MockTransport(handler)
+
+
+def test_openai_client_chat_completion_round_trip() -> None:
+    captured: Dict[str, Any] = {}
+    transport = _mock_chat_response("Model reply", captured)
+    http_client = httpx.Client(transport=transport, base_url="https://api.openai.com/v1")
+    client = OpenAIClient(api_key="test-key", client_kwargs={"http_client": http_client})
+
+    try:
+        content = client.chat(
+            "Hello there",
+            system_prompt="system message",
+            extra_messages=[{"role": "assistant", "content": "context"}],
+        )
+    finally:
+        client.client.close()
+
+    assert content == "Model reply"
+    payload = captured["payload"]
+    assert payload["model"] == "gpt-5-nano"
+    assert payload["messages"][0] == {"role": "system", "content": "system message"}
+    assert payload["messages"][1] == {"role": "user", "content": "Hello there"}
+    assert payload["messages"][2] == {"role": "assistant", "content": "context"}
+    headers = captured["headers"]
+    assert headers.get("user-agent") == "successat"
+
+
+def test_openrouter_client_includes_custom_headers_and_model_override() -> None:
+    captured: Dict[str, Any] = {}
+    transport = _mock_chat_response("Router reply", captured)
+    http_client = httpx.Client(transport=transport, base_url="https://openrouter.ai/api/v1")
+    client = OpenRouterClient(
+        api_key="router-key",
+        client_kwargs={"http_client": http_client},
+    )
+
+    try:
+        content = client.chat("Prompt", model="custom-model")
+    finally:
+        client.client.close()
+
+    assert content == "Router reply"
+    payload = captured["payload"]
+    assert payload["model"] == "custom-model"
+    headers = captured["headers"]
+    assert headers.get("http-referer") == "https://github.com/successat/successat"
+    assert headers.get("x-title") == "successat"
+    assert headers.get("user-agent") == "successat"

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -1,0 +1,56 @@
+"""Unit tests for the LLM client implementations."""
+
+import pytest
+
+from successat.llm.clients import OpenAIClient, OpenRouterClient
+
+
+def test_openai_client_requires_api_key() -> None:
+    with pytest.raises(ValueError):
+        OpenAIClient(api_key="")
+
+
+def test_openai_client_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    client = OpenAIClient.from_env()
+
+    try:
+        assert client.api_key == "test-key"
+        assert client.app_name == "successat"
+        assert client.model == "gpt-5-nano"
+    finally:
+        client.client.close()
+
+
+def test_openai_client_from_env_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(EnvironmentError):
+        OpenAIClient.from_env()
+
+
+def test_openrouter_client_default_configuration() -> None:
+    client = OpenRouterClient(api_key="router-key")
+
+    try:
+        headers = client.client.default_headers
+        assert headers["HTTP-Referer"] == "https://github.com/successat/successat"
+        assert headers["X-Title"] == "successat"
+        assert headers["User-Agent"] == "successat"
+        assert str(client.client._client.base_url) == "https://openrouter.ai/api/v1/"
+    finally:
+        client.client.close()
+
+
+def test_openrouter_client_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    client = OpenRouterClient.from_env()
+
+    try:
+        assert client.api_key == "router-key"
+        assert client.model == "gpt-5-nano"
+        assert client.app_name == "successat"
+    finally:
+        client.client.close()


### PR DESCRIPTION
## Summary
- add a shared base class plus OpenAI and OpenRouter client implementations that use the OpenAI SDK with `successat` defaults
- cover the new clients with unit tests and mocked integration tests via pytest
- document uv-based setup instructions and add a CI workflow that runs the pytest suite
- run provider-backed integration tests by default when credentials exist, mark them with `integtest`, and update contributor docs

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68c978e53120832b9537f211594b3dea