### PR TITLE
Add benchmark details CLI option

### DIFF
--- a/src/successat/benchmarks/base.py
+++ b/src/successat/benchmarks/base.py
@@ -90,6 +90,11 @@ class Benchmark:
     def __init__(self, client: SupportsChatCompletion) -> None:
         self.client = client
 
+    def available_splits(self) -> Sequence[str]:
+        """Return the collection of supported split names for the benchmark."""
+
+        return [self.default_split]
+
     # Public API ---------------------------------------------------------
     def run(
         self,

--- a/src/successat/benchmarks/gsm8k.py
+++ b/src/successat/benchmarks/gsm8k.py
@@ -28,6 +28,9 @@ class GSM8KBenchmark(Benchmark):
         super().__init__(client)
         self._examples_by_split: Dict[str, List[BenchmarkExample]] = {}
 
+    def available_splits(self) -> Sequence[str]:
+        return ["train", "test"]
+
     # Public API ---------------------------------------------------------
     def examples_for_split(self, split: str) -> Sequence[BenchmarkExample]:
         dataset_split = self._resolve_split(split)

--- a/src/successat/benchmarks/humaneval.py
+++ b/src/successat/benchmarks/humaneval.py
@@ -33,6 +33,9 @@ class HumanEvalBenchmark(Benchmark):
         super().__init__(client)
         self._examples: Dict[str, List[BenchmarkExample]] = {}
 
+    def available_splits(self) -> Sequence[str]:
+        return ["test"]
+
     def examples_for_split(self, split: str) -> Sequence[BenchmarkExample]:
         split_lower = split.lower()
         if split_lower != "test":

--- a/src/successat/benchmarks/mmlu.py
+++ b/src/successat/benchmarks/mmlu.py
@@ -38,6 +38,9 @@ class MMLUBenchmark(Benchmark):
         self._examples_by_dataset_split: Dict[str, List[BenchmarkExample]] = {}
         self._alias_cache: Dict[str, List[BenchmarkExample]] = {}
 
+    def available_splits(self) -> Sequence[str]:
+        return ["auxiliary_train", "dev", "validation", "test"]
+
     def examples_for_split(self, split: str) -> Sequence[BenchmarkExample]:
         alias = split.lower()
         if alias in self._alias_cache:

--- a/src/successat/benchmarks/triviaqa.py
+++ b/src/successat/benchmarks/triviaqa.py
@@ -53,6 +53,14 @@ class TriviaQABenchmark(Benchmark):
         self._arc_examples: Dict[str, List[BenchmarkExample]] = {}
         self._combined_cache: Dict[str, List[BenchmarkExample]] = {}
 
+    def available_splits(self) -> Sequence[str]:
+        combined = ["train", "validation", "test"]
+        trivia_splits = sorted({value for value in self._TRIVIA_SPLIT_ALIASES.values()})
+        arc_splits = sorted({value for value in self._ARC_SPLIT_ALIASES.values()})
+        trivia_specs = [f"triviaqa:{split}" for split in trivia_splits]
+        arc_specs = [f"arc_easy:{split}" for split in arc_splits]
+        return [*combined, *trivia_specs, *arc_specs]
+
     def examples_for_split(self, split: str) -> Sequence[BenchmarkExample]:
         spec = self._resolve_split_spec(split)
         kind = spec["kind"]


### PR DESCRIPTION
## Summary
- add a `--benchmark-details` CLI flag that reports each split with example counts
- expose `available_splits` on benchmarks so the CLI can introspect datasets
- cover the new behaviour with a dedicated CLI unit test

## Testing
- `uv run --env-file .env pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb177837d0832ba2d20befc0643588