### PR TITLE
Improve packaging metadata and docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 aplassard and codex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ uv sync
 This will create a local virtual environment under `.venv/` if one does not
 already exist.
 
+## Installing the package with `uv`
+
+When you want to use the library outside of the development environment, you
+can install it directly with `uv`:
+
+```bash
+uv pip install .
+```
+
+Once the repository is published or if you want to consume it directly from
+GitHub without cloning first, install from the hosted repository:
+
+```bash
+uv pip install git+https://github.com/aplassard/successat.git
+```
+
+Both commands build the package metadata declared in `pyproject.toml`, so the
+console script and modules are available immediately after installation.
+
 ## Running the test suite
 
 Unit and integration tests are managed with `pytest`. By default the suite will

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,22 @@
 [project]
 name = "successat"
 version = "0.1.0"
-description = "Add your description here"
+description = "Reusable benchmarking utilities for provider-agnostic LLM clients"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "openai>=1.30.0",
-    "pytest>=7.4",
     "datasets>=4.0.0",
 ]
+authors = [
+    { name = "aplassard" },
+    { name = "codex" },
+]
+license = { file = "LICENSE" }
+
+[project.urls]
+Homepage = "https://github.com/aplassard/successat"
+Repository = "https://github.com/aplassard/successat"
 
 [project.scripts]
 successat = "successat.cli:main"
@@ -32,4 +40,9 @@ pythonpath = [
 ]
 markers = [
     "integtest: marks tests that call real provider APIs",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=7.4",
 ]


### PR DESCRIPTION
## Summary
- add authors, license, and project URLs to `pyproject.toml`
- move `pytest` to uv dev dependencies and update the package description
- document uv installation commands and include the MIT license file

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb5d43da30832b8096fe39b9142584