### PR TITLE
Add HumanEval+ benchmark dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ execution will download the corresponding dataset artefacts to the local cache.
   `test`.
 * **HumanEval** – evaluates generated code against the official
   `openai_humaneval` test harness.
+* **HumanEval+** – runs the EvalPlus `evalplus/humanevalplus` variant with
+  augmented unit tests derived from the original problems.
 * **TriviaQA / ARC** – combines the
   `TimoImhof/Splits_Subset_TriviaQa` subset for free-form answers with the
   `ai2_arc` `ARC-Easy` and `ARC-Challenge` configurations for multiple choice

--- a/src/successat/benchmarks/__init__.py
+++ b/src/successat/benchmarks/__init__.py
@@ -12,7 +12,7 @@ from .base import (
     SupportsChatCompletion,
 )
 from .gsm8k import GSM8KBenchmark
-from .humaneval import HumanEvalBenchmark
+from .humaneval import HumanEvalBenchmark, HumanEvalPlusBenchmark
 from .mmlu import MMLUBenchmark
 from .triviaqa import TriviaQABenchmark
 
@@ -23,6 +23,7 @@ __all__ = [
     "BenchmarkResult",
     "GSM8KBenchmark",
     "HumanEvalBenchmark",
+    "HumanEvalPlusBenchmark",
     "MMLUBenchmark",
     "TriviaQABenchmark",
     "benchmark_registry",
@@ -41,7 +42,13 @@ def register_benchmarks(registry: BenchmarkRegistry, benchmarks: Iterable[Type[B
 benchmark_registry = BenchmarkRegistry()
 register_benchmarks(
     benchmark_registry,
-    (GSM8KBenchmark, MMLUBenchmark, HumanEvalBenchmark, TriviaQABenchmark),
+    (
+        GSM8KBenchmark,
+        MMLUBenchmark,
+        HumanEvalBenchmark,
+        HumanEvalPlusBenchmark,
+        TriviaQABenchmark,
+    ),
 )
 
 

--- a/src/successat/benchmarks/humaneval.py
+++ b/src/successat/benchmarks/humaneval.py
@@ -28,6 +28,7 @@ class HumanEvalBenchmark(Benchmark):
     description = "Python function synthesis with execution-based scoring."
     dataset_name = "openai_humaneval"
     default_split = "test"
+    example_id_prefix = "humaneval"
 
     def __init__(self, client):
         super().__init__(client)
@@ -103,10 +104,19 @@ class HumanEvalBenchmark(Benchmark):
         )
 
         return BenchmarkExample(
-            id=f"humaneval-{task_id}",
+            id=f"{self.example_id_prefix}-{task_id}",
             prompt=prompt,
             target=entry_point,
             metadata=metadata,
             system_prompt=system_prompt,
         )
+
+
+class HumanEvalPlusBenchmark(HumanEvalBenchmark):
+    """Evaluate HumanEval+ problems using the EvalPlus augmented test suite."""
+
+    name = "humaneval+"
+    description = "Python synthesis with the HumanEval+ extended unit tests."
+    dataset_name = "evalplus/humanevalplus"
+    example_id_prefix = "humanevalplus"
 

--- a/src/successat/cli.py
+++ b/src/successat/cli.py
@@ -32,7 +32,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--benchmark",
         "-b",
-        help="Name of the benchmark to execute (e.g. gsm8k, mmlu, humaneval).",
+        help="Name of the benchmark to execute (e.g. gsm8k, mmlu, humaneval, humaneval+).",
     )
     parser.add_argument(
         "--client",

--- a/tests/integration/test_benchmarks_live_end_to_end.py
+++ b/tests/integration/test_benchmarks_live_end_to_end.py
@@ -117,6 +117,30 @@ def test_humaneval_benchmark_live_round_trip(
         assert "error" in details
 
 
+def test_humaneval_plus_benchmark_live_round_trip(
+    live_openai_client: OpenAIClient, benchmark_model: str
+) -> None:
+    result = _run(
+        live_openai_client,
+        "humaneval+",
+        identifier=0,
+        split="test",
+        model=benchmark_model,
+    )
+
+    entry_point = result.metadata["entry_point"]
+    assert result.benchmark == "humaneval+"
+    assert entry_point
+    assert f"def {entry_point}" in result.prompt
+    assert result.metadata["canonical_solution"]
+    assert result.response_text.strip()
+
+    if not result.correct:
+        details = result.metadata.get("evaluation_details")
+        assert details is not None
+        assert "error" in details
+
+
 def test_triviaqa_short_answer_live_round_trip(
     live_openai_client: OpenAIClient, benchmark_model: str
 ) -> None:

--- a/tests/unit/test_benchmark_registry.py
+++ b/tests/unit/test_benchmark_registry.py
@@ -7,6 +7,7 @@ import pytest
 from successat.benchmarks import (
     GSM8KBenchmark,
     HumanEvalBenchmark,
+    HumanEvalPlusBenchmark,
     MMLUBenchmark,
     TriviaQABenchmark,
     benchmark_registry,
@@ -18,7 +19,7 @@ from successat.benchmarks.base import BenchmarkRegistry
 
 def test_registry_contains_default_benchmarks() -> None:
     names = set(benchmark_registry.names())
-    assert {"gsm8k", "mmlu", "humaneval", "triviaqa"}.issubset(names)
+    assert {"gsm8k", "mmlu", "humaneval", "humaneval+", "triviaqa"}.issubset(names)
 
 
 def test_register_benchmarks_rejects_duplicates() -> None:


### PR DESCRIPTION
## Summary
- add a HumanEvalPlus benchmark that loads the EvalPlus dataset and expose it via the registry and CLI
- document the new benchmark option in the README and extend coverage with unit and integration tests

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb66111c18832b931522e6977f4191