### PR TITLE
Add cached dataset loader for benchmarks

### DIFF
--- a/src/successat/benchmarks/gsm8k.py
+++ b/src/successat/benchmarks/gsm8k.py
@@ -6,7 +6,7 @@ import re
 from decimal import Decimal, InvalidOperation
 from typing import Dict, List, Sequence
 
-from datasets import load_dataset
+from ..datasets import load_dataset
 
 from .base import Benchmark, BenchmarkExample
 

--- a/src/successat/benchmarks/humaneval.py
+++ b/src/successat/benchmarks/humaneval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import textwrap
 from typing import Dict, List, Sequence
 
-from datasets import load_dataset
+from ..datasets import load_dataset
 
 from .base import Benchmark, BenchmarkExample
 

--- a/src/successat/benchmarks/mmlu.py
+++ b/src/successat/benchmarks/mmlu.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Dict, List, Mapping, Sequence
 
-from datasets import load_dataset
+from ..datasets import load_dataset
 
 from .base import Benchmark, BenchmarkExample
 

--- a/src/successat/benchmarks/triviaqa.py
+++ b/src/successat/benchmarks/triviaqa.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Dict, Iterable, List, Mapping, Sequence, Tuple, TypedDict
 
-from datasets import load_dataset
+from ..datasets import load_dataset
 
 from .base import Benchmark, BenchmarkExample
 

--- a/src/successat/cache.py
+++ b/src/successat/cache.py
@@ -1,0 +1,36 @@
+"""Utilities for managing successat cache directories."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_CACHE_ENV_VAR = "SUCCESSAT_CACHE_DIR"
+
+
+def cache_root() -> Path:
+    """Return the root directory for successat caches.
+
+    The location can be overridden by setting the ``SUCCESSAT_CACHE_DIR``
+    environment variable. When unset, the default is ``~/.successat/cache``.
+    The directory is created if it does not already exist.
+    """
+
+    override = os.environ.get(_CACHE_ENV_VAR)
+    if override:
+        root = Path(override).expanduser()
+    else:
+        root = Path.home() / ".successat" / "cache"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def cache_subdir(*parts: str) -> Path:
+    """Return a subdirectory of the cache root, creating it if needed."""
+
+    root = cache_root()
+    if not parts:
+        return root
+    subdir = root.joinpath(*parts)
+    subdir.mkdir(parents=True, exist_ok=True)
+    return subdir

--- a/src/successat/datasets.py
+++ b/src/successat/datasets.py
@@ -1,0 +1,33 @@
+"""Wrappers around dataset loading utilities with successat-specific defaults."""
+
+from __future__ import annotations
+
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+from datasets import load_dataset as _HF_LOAD_DATASET
+
+from .cache import cache_subdir
+
+
+def _prepare_cache_dir(cache_dir: str | PathLike[str] | None) -> Path:
+    if cache_dir is None:
+        return cache_subdir("datasets")
+    path = Path(cache_dir).expanduser()
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def load_dataset(*args: Any, **kwargs: Any):
+    """Load a dataset using HuggingFace with successat caching defaults.
+
+    The cache directory defaults to ``~/.successat/cache/datasets`` but can be
+    overridden either by passing ``cache_dir`` explicitly or by setting the
+    ``SUCCESSAT_CACHE_DIR`` environment variable.
+    """
+
+    cache_path = _prepare_cache_dir(kwargs.pop("cache_dir", None))
+    kwargs.setdefault("download_mode", "reuse_cache_if_exists")
+
+    return _HF_LOAD_DATASET(*args, cache_dir=str(cache_path), **kwargs)

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -1,0 +1,51 @@
+"""Tests for the dataset loading helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+import successat.datasets as datasets_module
+
+
+@pytest.fixture(autouse=True)
+def reset_cache_env(monkeypatch):
+    """Ensure cache env var is not leaked between tests."""
+
+    monkeypatch.delenv("SUCCESSAT_CACHE_DIR", raising=False)
+
+
+def test_load_dataset_uses_successat_cache_dir(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_load_dataset(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {"name": "dummy"}
+
+    monkeypatch.setenv("SUCCESSAT_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(datasets_module, "_HF_LOAD_DATASET", fake_load_dataset)
+
+    result = datasets_module.load_dataset("dummy")
+
+    assert result == {"name": "dummy"}
+    expected_dir = tmp_path / "datasets"
+    assert captured["kwargs"]["cache_dir"] == str(expected_dir)
+    assert expected_dir.exists()
+    assert captured["kwargs"]["download_mode"] == "reuse_cache_if_exists"
+
+
+def test_load_dataset_respects_explicit_cache_dir(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_load_dataset(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return {"name": "explicit"}
+
+    monkeypatch.setattr(datasets_module, "_HF_LOAD_DATASET", fake_load_dataset)
+
+    custom_cache = tmp_path / "custom"
+    result = datasets_module.load_dataset("dummy", cache_dir=custom_cache)
+
+    assert result == {"name": "explicit"}
+    assert captured["kwargs"]["cache_dir"] == str(custom_cache)
+    assert custom_cache.exists()


### PR DESCRIPTION
## Summary
- add cache utilities and a HuggingFace dataset loader wrapper that stores data under `~/.successat/cache`
- switch benchmark implementations to use the shared cached loader instead of importing `datasets.load_dataset` directly
- cover the caching behaviour with new unit tests

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc5ece6580832ba62f368c91f7d8aa