### PR TITLE
Add default timeout and retries to LLM clients

### DIFF
--- a/src/successat/llm/clients.py
+++ b/src/successat/llm/clients.py
@@ -139,6 +139,8 @@ class OpenAIClient(BaseLLMClient):
         headers = self._build_default_headers()
         client_kwargs = self._pop_client_kwargs()
         client_kwargs.setdefault("default_headers", headers)
+        client_kwargs.setdefault("timeout", 60.0)
+        client_kwargs.setdefault("max_retries", 3)
 
         return OpenAI(api_key=self.api_key, **client_kwargs)
 
@@ -186,6 +188,8 @@ class OpenRouterClient(BaseLLMClient):
     def _create_client(self) -> OpenAI:  # pragma: no cover - exercised in integration tests
         headers = self._build_default_headers()
         client_kwargs = dict(self._client_kwargs)
+        client_kwargs.setdefault("timeout", 60.0)
+        client_kwargs.setdefault("max_retries", 3)
         client_kwargs.pop("default_headers", None)
         base_url = client_kwargs.pop("base_url", self.base_url)
 

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -19,6 +19,8 @@ def test_openai_client_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         assert client.api_key == "test-key"
         assert client.app_name == "successat"
         assert client.model == "gpt-5-nano"
+        assert client.client.timeout == 60.0
+        assert client.client.max_retries == 3
     finally:
         client.client.close()
 
@@ -39,6 +41,31 @@ def test_openrouter_client_default_configuration() -> None:
         assert headers["X-Title"] == "successat"
         assert headers["User-Agent"] == "successat"
         assert str(client.client._client.base_url) == "https://openrouter.ai/api/v1/"
+        assert client.client.timeout == 60.0
+        assert client.client.max_retries == 3
+    finally:
+        client.client.close()
+
+
+def test_openai_client_allows_overriding_timeout_and_retries() -> None:
+    client = OpenAIClient(api_key="key", client_kwargs={"timeout": 10.0, "max_retries": 5})
+
+    try:
+        assert client.client.timeout == 10.0
+        assert client.client.max_retries == 5
+    finally:
+        client.client.close()
+
+
+def test_openrouter_client_allows_overriding_timeout_and_retries() -> None:
+    client = OpenRouterClient(
+        api_key="router-key",
+        client_kwargs={"timeout": 15.0, "max_retries": 4},
+    )
+
+    try:
+        assert client.client.timeout == 15.0
+        assert client.client.max_retries == 4
     finally:
         client.client.close()
 


### PR DESCRIPTION
## Summary
- set 60 second timeout and 3 retries by default for the OpenAI and OpenRouter clients
- ensure custom client options can override the timeout and retry defaults through new unit tests

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc756c67f4832ba63c6b880a33fde7