### PR TITLE
Improve LiveBench response parsing

### DIFF
--- a/src/successat/benchmarks/livebench.py
+++ b/src/successat/benchmarks/livebench.py
@@ -23,6 +23,8 @@ from .base import Benchmark, BenchmarkExample
 
 
 _CODE_FENCE_RE = re.compile(r"^```(?:python)?\s*|```$", re.IGNORECASE | re.MULTILINE)
+_CODE_BLOCK_RE = re.compile(r"```(?:python)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+_SOLUTION_CLASS_RE = re.compile(r"^\s*class\s+Solution\b", re.MULTILINE)
 _SIGNATURE_RE = re.compile(r"def\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)")
 
 
@@ -246,6 +248,14 @@ class LiveBenchCodingBenchmark(Benchmark):
 
     @staticmethod
     def _strip_code_fence(text: str) -> str:
+        fenced_blocks = _CODE_BLOCK_RE.findall(text)
+        if fenced_blocks:
+            return fenced_blocks[-1].strip()
+
+        match = _SOLUTION_CLASS_RE.search(text)
+        if match:
+            return text[match.start() :].strip()
+
         return _CODE_FENCE_RE.sub("", text).strip()
 
     @staticmethod


### PR DESCRIPTION
## Summary
- update LiveBench parsing to prefer the final fenced block and fall back to the first `class Solution` declaration
- extend the benchmark tests to cover responses with explanatory text surrounding the code

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc9fea9798832bba0506c2d70558a7