### PR TITLE
Add LiveBench reasoning and math benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ execution will download the corresponding dataset artefacts to the local cache.
   `openai_humaneval` test harness.
 * **HumanEval+** – runs the EvalPlus `evalplus/humanevalplus` variant with
   augmented unit tests derived from the original problems.
+* **LiveBench Coding** – executes LiveBench coding problems against public and
+  private unit tests sourced from the `livebench/coding` dataset. Splits
+  include rolling monthly releases alongside historical groupings.
+* **LiveBench Reasoning** – scores structured logic tasks from
+  `livebench/reasoning` by comparing the answers in the `<solution>` block with
+  the ground truth tuples.
+* **LiveBench Math** – validates LiveBench math puzzles from `livebench/math`
+  by matching the ordered list of expression identifiers provided in the
+  authoritative solutions.
 * **TriviaQA / ARC** – combines the
   `TimoImhof/Splits_Subset_TriviaQa` subset for free-form answers with the
   `ai2_arc` `ARC-Easy` and `ARC-Challenge` configurations for multiple choice

--- a/src/successat/benchmarks/__init__.py
+++ b/src/successat/benchmarks/__init__.py
@@ -13,7 +13,11 @@ from .base import (
 )
 from .gsm8k import GSM8KBenchmark
 from .humaneval import HumanEvalBenchmark, HumanEvalPlusBenchmark
-from .livebench import LiveBenchCodingBenchmark
+from .livebench import (
+    LiveBenchCodingBenchmark,
+    LiveBenchMathBenchmark,
+    LiveBenchReasoningBenchmark,
+)
 from .mmlu import MMLUBenchmark
 from .triviaqa import TriviaQABenchmark
 
@@ -27,6 +31,8 @@ __all__ = [
     "HumanEvalPlusBenchmark",
     "MMLUBenchmark",
     "LiveBenchCodingBenchmark",
+    "LiveBenchMathBenchmark",
+    "LiveBenchReasoningBenchmark",
     "TriviaQABenchmark",
     "benchmark_registry",
     "register_benchmarks",
@@ -50,6 +56,8 @@ register_benchmarks(
         HumanEvalBenchmark,
         HumanEvalPlusBenchmark,
         LiveBenchCodingBenchmark,
+        LiveBenchReasoningBenchmark,
+        LiveBenchMathBenchmark,
         TriviaQABenchmark,
     ),
 )

--- a/src/successat/cli.py
+++ b/src/successat/cli.py
@@ -37,7 +37,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "-b",
         help=(
             "Name of the benchmark to execute (e.g. gsm8k, mmlu, humaneval, "
-            "humaneval+, livebench-coding)."
+            "humaneval+, livebench-coding, livebench-reasoning, livebench-math)."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- refactor the LiveBench implementation to share split preparation helpers and add reasoning and math benchmark variants with deterministic scoring
- expose the new benchmarks through the public registry/CLI surface and document their availability
- cover the new evaluators with unit tests for solution parsing and scoring edge cases

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cca5e7e4d4832b997294a48d4a012f