### PR TITLE
Add benchmark timing metrics and surface them in the CLI

### DIFF
--- a/src/successat/benchmarks/base.py
+++ b/src/successat/benchmarks/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from time import perf_counter
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Protocol, Sequence
 
 
@@ -31,6 +32,8 @@ class BenchmarkResult:
     response_text: str
     correct: bool
     metadata: Dict[str, Any]
+    time_to_first_token: float | None = None
+    total_time: float | None = None
 
 
 class SupportsChatCompletion(Protocol):
@@ -108,7 +111,9 @@ class Benchmark:
         chosen_split = split or self.default_split
         example = self._select_example(chosen_split, identifier)
         prompt = self.build_prompt(example)
+        start_time = perf_counter()
         response = self._call_model(example, prompt, **kwargs)
+        total_elapsed = perf_counter() - start_time
         response_text = self.extract_text(response)
         correct, details = self.is_correct(example, response_text, response)
 
@@ -116,6 +121,27 @@ class Benchmark:
         metadata.setdefault("expected", example.target)
         if details:
             metadata["evaluation_details"] = details
+
+        time_to_first_token = _extract_timing_value(response, "time_to_first_token")
+        total_time = _extract_timing_value(response, "total_time")
+
+        metadata_time_to_first = _coerce_float(metadata.get("time_to_first_token"))
+        metadata_total_time = _coerce_float(metadata.get("total_time"))
+
+        if time_to_first_token is None:
+            time_to_first_token = metadata_time_to_first
+        if total_time is None:
+            total_time = metadata_total_time
+
+        if time_to_first_token is None:
+            time_to_first_token = total_elapsed
+        if total_time is None:
+            total_time = total_elapsed
+
+        if _should_set_timing(metadata, "time_to_first_token"):
+            metadata["time_to_first_token"] = time_to_first_token
+        if _should_set_timing(metadata, "total_time"):
+            metadata["total_time"] = total_time
 
         return BenchmarkResult(
             benchmark=self.name,
@@ -127,6 +153,8 @@ class Benchmark:
             response_text=response_text,
             correct=correct,
             metadata=metadata,
+            time_to_first_token=time_to_first_token,
+            total_time=total_time,
         )
 
     # Hooks for subclasses -----------------------------------------------
@@ -249,4 +277,72 @@ class Benchmark:
 
     def _model_name(self) -> str:
         return getattr(self.client, "model", "unknown")
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Attempt to convert ``value`` into a floating point number."""
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+
+    return None
+
+
+def _should_set_timing(metadata: MutableMapping[str, Any], key: str) -> bool:
+    """Return ``True`` if the timing metadata for ``key`` should be set."""
+
+    if key not in metadata:
+        return True
+
+    return metadata[key] is None
+
+
+def _extract_timing_value(response: Any, key: str) -> float | None:
+    """Inspect ``response`` for a timing attribute named ``key``."""
+
+    to_inspect: list[Any] = [response]
+    seen: set[int] = set()
+
+    while to_inspect:
+        current = to_inspect.pop()
+        if current is None:
+            continue
+
+        if isinstance(current, (str, bytes, bytearray)):
+            continue
+
+        identifier = id(current)
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+
+        if isinstance(current, Mapping):
+            if key in current:
+                coerced = _coerce_float(current[key])
+                if coerced is not None:
+                    return coerced
+
+            for nested_key in ("usage", "timings", "meta", "metadata"):
+                nested = current.get(nested_key)
+                if nested is not None:
+                    to_inspect.append(nested)
+
+        value = getattr(current, key, None)
+        if value is not None:
+            coerced = _coerce_float(value)
+            if coerced is not None:
+                return coerced
+
+        for attr in ("usage", "timings", "meta", "metadata", "model_extra"):
+            nested = getattr(current, attr, None)
+            if nested is not None:
+                to_inspect.append(nested)
+
+    return None
 

--- a/src/successat/cli.py
+++ b/src/successat/cli.py
@@ -249,9 +249,15 @@ def _format_result(result: BenchmarkResult) -> str:
         formatted_prompt,
         "Response:",
         formatted_response,
-        "Metadata:",
-        metadata,
     ]
+
+    if result.time_to_first_token is not None:
+        output_lines.append(f"Time to first token: {result.time_to_first_token:.3f} s")
+
+    if result.total_time is not None:
+        output_lines.append(f"Total time: {result.total_time:.3f} s")
+
+    output_lines.extend(["Metadata:", metadata])
     return "\n".join(output_lines)
 
 
@@ -284,6 +290,8 @@ def _log_result(result: BenchmarkResult, directory: Path) -> Path:
         "response_text": result.response_text,
         "correct": result.correct,
         "metadata": _sanitize_for_json(result.metadata),
+        "time_to_first_token": result.time_to_first_token,
+        "total_time": result.total_time,
     }
 
     try:

--- a/tests/unit/test_benchmark_base.py
+++ b/tests/unit/test_benchmark_base.py
@@ -1,0 +1,73 @@
+"""Unit tests covering benchmark timing enrichment."""
+
+from __future__ import annotations
+
+import pytest
+
+import successat.benchmarks.base as base_module
+from successat.benchmarks.base import Benchmark, BenchmarkExample
+
+
+class _TimingBenchmark(Benchmark):
+    """Minimal benchmark used to exercise timing behaviour."""
+
+    name = "timing-demo"
+
+    def __init__(self, client, *, metadata: dict[str, object] | None = None) -> None:  # type: ignore[override]
+        super().__init__(client)
+        self._metadata = metadata or {}
+
+    def examples_for_split(self, split: str):  # type: ignore[override]
+        return [
+            BenchmarkExample(
+                id="example-0",
+                prompt="prompt",
+                target="response",
+                metadata=dict(self._metadata),
+            )
+        ]
+
+
+def test_run_populates_timing_metadata(monkeypatch: pytest.MonkeyPatch, fake_llm_client) -> None:
+    """Benchmarks should add timing metadata when it is missing."""
+
+    times = iter([10.0, 10.5])
+
+    def fake_perf_counter() -> float:
+        return next(times)
+
+    monkeypatch.setattr(base_module, "perf_counter", fake_perf_counter)
+
+    client = fake_llm_client(["response"])
+    benchmark = _TimingBenchmark(client)
+
+    result = benchmark.run()
+
+    assert result.time_to_first_token == pytest.approx(0.5)
+    assert result.total_time == pytest.approx(0.5)
+    assert result.metadata["time_to_first_token"] == pytest.approx(0.5)
+    assert result.metadata["total_time"] == pytest.approx(0.5)
+
+
+def test_run_preserves_existing_timing_metadata(monkeypatch: pytest.MonkeyPatch, fake_llm_client) -> None:
+    """Pre-existing timing metadata should be preferred over measured durations."""
+
+    times = iter([100.0, 101.0])
+
+    def fake_perf_counter() -> float:
+        return next(times)
+
+    monkeypatch.setattr(base_module, "perf_counter", fake_perf_counter)
+
+    metadata = {"time_to_first_token": "1.2", "total_time": 3.4}
+    client = fake_llm_client(["response"])
+    benchmark = _TimingBenchmark(client, metadata=metadata)
+
+    result = benchmark.run()
+
+    assert result.time_to_first_token == pytest.approx(1.2)
+    assert result.total_time == pytest.approx(3.4)
+    # Existing metadata values should remain untouched.
+    assert result.metadata["time_to_first_token"] == "1.2"
+    assert result.metadata["total_time"] == 3.4
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -56,6 +56,8 @@ def _build_result() -> BenchmarkResult:
         response_text="model response",
         correct=True,
         metadata={"expected": "model response"},
+        time_to_first_token=0.321,
+        total_time=0.654,
     )
 
 
@@ -110,6 +112,8 @@ def test_cli_runs_benchmark(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Capt
     out = capsys.readouterr().out
     assert "Benchmark: gsm8k" in out
     assert "Response:\nmodel response" in out
+    assert "Time to first token: 0.321 s" in out
+    assert "Total time: 0.654 s" in out
 
     client = recorded["client"]
     assert isinstance(client, _DummyClient)
@@ -235,6 +239,8 @@ def test_cli_logs_results_to_directory(
     assert payload["benchmark"] == "gsm8k"
     assert payload["model"] == "dummy-model"
     assert payload["correct"] is True
+    assert payload["time_to_first_token"] == 0.321
+    assert payload["total_time"] == 0.654
 
 
 def test_cli_requires_directory_for_logging(


### PR DESCRIPTION
## Summary
- record benchmark execution timings and include them in BenchmarkResult
- surface time-to-first-token and total execution time in CLI output and result logs
- add regression tests covering benchmark timing enrichment and CLI display

## Testing
- uv run --env-file .env pytest

------
https://chatgpt.com/codex/tasks/task_e_68cecf193874832bbf949fa67195e9ce